### PR TITLE
BREAKING: new API, `measureStart` and `measureEnd`

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,6 +24,7 @@ pane.registerPlugin( TweakpaneProfilerBladePlugin );
 const profiler = pane.addBlade( {
   view: 'profiler',
   label: 'profiler',
+  targetDelta: 1, // 16ms by default
 } );
 
 console.log( profiler );
@@ -44,7 +45,7 @@ function abuseSin() {
 }
 
 function abuseFind() {
-  for ( let sum = 0; sum < 1E5; sum ++ ) {
+  for ( let sum = 0; sum < 1E4; sum ++ ) {
     /define/.test( 'undefined' );
   }
 }
@@ -55,20 +56,25 @@ let stop = false;
 function update() {
   if ( stop ) { return; }
 
+  // the lambda inside the `profiler.measure` is measured
   profiler.measure( 'update', () => {
+    // the `profiler.measure` can be nested and displayed in a hierarchy
     profiler.measure( 'math', () => {
+      // even more hierarchy
       profiler.measure( 'abuseRandom', () => {
         abuseRandom();
       } );
 
+      // another item on the same level
       profiler.measure( 'abuseSin', () => {
         abuseSin();
       } );
     } );
 
-    profiler.measure( 'abuseFind', () => {
-      abuseFind();
-    } );
+    // you can use a more classic way as well
+    profiler.measureStart( 'abuseFind' );
+    abuseFind();
+    profiler.measureEnd();
   } );
 
   requestAnimationFrame( update );

--- a/src/ProfilerBladeApi.ts
+++ b/src/ProfilerBladeApi.ts
@@ -3,8 +3,16 @@ import type { ProfilerBladeController } from './ProfilerBladeController.js';
 import type { ProfilerBladeMeasureHandler } from './ProfilerBladeMeasureHandler.js';
 
 export class ProfilerBladeApi extends BladeApi<ProfilerBladeController> {
-  public measure( name: string, fn: () => void ): void {
-    this.controller.valueController.measure( name, fn );
+  public measureStart( name: string ): void {
+    this.controller.valueController.measureStart( name );
+  }
+
+  public measureEnd(): Promise<void> {
+    return this.controller.valueController.measureEnd();
+  }
+
+  public measure( name: string, fn: () => void ): Promise<void> {
+    return this.controller.valueController.measure( name, fn );
   }
 
   public get measureHandler(): ProfilerBladeMeasureHandler {

--- a/src/ProfilerBladeDefaultMeasureHandler.ts
+++ b/src/ProfilerBladeDefaultMeasureHandler.ts
@@ -1,13 +1,8 @@
 import type { ProfilerBladeMeasureHandler } from './ProfilerBladeMeasureHandler.js';
 
 export class ProfilerBladeDefaultMeasureHandler implements ProfilerBladeMeasureHandler {
-  public measure( fn: () => void ): number {
+  public measureStart(): () => number {
     const begin = performance.now();
-
-    fn();
-
-    const delta = performance.now() - begin;
-
-    return delta;
+    return () => performance.now() - begin;
   }
 }

--- a/src/ProfilerBladeMeasureHandler.ts
+++ b/src/ProfilerBladeMeasureHandler.ts
@@ -1,3 +1,3 @@
 export interface ProfilerBladeMeasureHandler {
-  measure: ( fn: () => void ) => number | Promise<number>;
+  measureStart: () => () => number | Promise<number>;
 }

--- a/src/ProfilerBladePlugin.ts
+++ b/src/ProfilerBladePlugin.ts
@@ -1,8 +1,8 @@
-import { MicroParser, ValueMap, createPlugin, parseRecord } from '@tweakpane/core';
 import { ProfilerBladeApi } from './ProfilerBladeApi.js';
 import { ProfilerBladeController } from './ProfilerBladeController.js';
 import { ProfilerBladeDefaultMeasureHandler } from './ProfilerBladeDefaultMeasureHandler.js';
 import { ProfilerController } from './ProfilerController.js';
+import { ValueMap, createPlugin, parseRecord } from '@tweakpane/core';
 import { createTicker } from './utils/createTicker.js';
 import type { BladePlugin, LabelPropsObject } from '@tweakpane/core';
 import type { ProfilerBladeMeasureHandler } from './ProfilerBladeMeasureHandler.js';
@@ -15,6 +15,17 @@ function parseCalcMode( value: unknown ): 'frame' | 'mean' | 'median' | undefine
   case 'median':
     return value;
   default:
+    return undefined;
+  }
+}
+
+function parseMeasureHandler( value: unknown ): ProfilerBladeMeasureHandler | undefined {
+  if ( typeof value === 'object' && value != null && 'measureStart' in value ) {
+    return value as ProfilerBladeDefaultMeasureHandler;
+  } else {
+    if ( typeof value === 'object' && value != null && 'measure' in value ) {
+      console.warn( 'The API of `ProfilerBladeDefaultMeasureHandler` has been changed in v0.4.0! Please define `measureStart` instead of `measure`. Fallback to the default measure handler.' );
+    }
     return undefined;
   }
 }
@@ -34,7 +45,7 @@ export const ProfilerBladePlugin: BladePlugin<ProfilerBladePluginParams> = creat
       calcMode: p.optional.custom( parseCalcMode ),
       label: p.optional.string,
       interval: p.optional.number,
-      measureHandler: p.optional.raw as MicroParser<ProfilerBladeMeasureHandler>,
+      measureHandler: p.optional.custom( parseMeasureHandler ),
     } ) );
 
     return result ? { params: result } : null;

--- a/src/ProfilerController.ts
+++ b/src/ProfilerController.ts
@@ -94,9 +94,9 @@ export class ProfilerController implements Controller<ProfilerView> {
     calcCache.latest = selfDelta;
   }
 
-  public async measure( name: string, fn: () => void ): Promise<void> {
+  public async measure( name: string, fn: () => void | Promise<void> ): Promise<void> {
     this.measureStart( name );
-    fn();
+    await fn();
     this.measureEnd();
   }
 

--- a/src/ProfilerController.ts
+++ b/src/ProfilerController.ts
@@ -16,6 +16,7 @@ interface CalcCache {
   meanCalc: HistoryMeanCalculator;
   medianCalc: HistoryPercentileCalculator;
   latest: number;
+  measureEnd: ( () => number | Promise<number> ) | null;
   childrenCacheMap: ConsecutiveCacheMap<string, CalcCache>;
   childrenPromiseDelta: Promise<number>[];
 }
@@ -60,9 +61,9 @@ export class ProfilerController implements Controller<ProfilerView> {
     this.rootCalcCacheStack_ = [ this.createNewEntryCalcCache_() ];
   }
 
-  public async measure( name: string, fn: () => void ): Promise<void> {
-    const parent = this.rootCalcCacheStack_[ this.rootCalcCacheStack_.length - 1 ];
-    const calcCache = parent.childrenCacheMap.getOrCreate(
+  public measureStart( name: string ): void {
+    const parentCalcCache = this.rootCalcCacheStack_[ this.rootCalcCacheStack_.length - 1 ];
+    const calcCache = parentCalcCache.childrenCacheMap.getOrCreate(
       name,
       () => this.createNewEntryCalcCache_(),
     );
@@ -70,8 +71,16 @@ export class ProfilerController implements Controller<ProfilerView> {
     arrayClear( calcCache.childrenPromiseDelta );
     this.rootCalcCacheStack_.push( calcCache );
 
-    const promiseDelta = Promise.resolve( this.measureHandler.measure( fn ) );
-    parent.childrenPromiseDelta.push( promiseDelta );
+    calcCache.measureEnd = this.measureHandler.measureStart();
+  }
+
+  public async measureEnd(): Promise<void> {
+    const calcCache = this.rootCalcCacheStack_[ this.rootCalcCacheStack_.length - 1 ];
+    const parentCalcCache = this.rootCalcCacheStack_[ this.rootCalcCacheStack_.length - 2 ];
+
+    const promiseDelta = Promise.resolve( calcCache.measureEnd!() );
+    calcCache.measureEnd = null;
+    parentCalcCache.childrenPromiseDelta.push( promiseDelta );
 
     this.rootCalcCacheStack_.pop();
     calcCache.childrenCacheMap.vaporize();
@@ -83,6 +92,12 @@ export class ProfilerController implements Controller<ProfilerView> {
     calcCache.meanCalc.push( selfDelta );
     calcCache.medianCalc.push( selfDelta );
     calcCache.latest = selfDelta;
+  }
+
+  public async measure( name: string, fn: () => void ): Promise<void> {
+    this.measureStart( name );
+    fn();
+    this.measureEnd();
   }
 
   public renderEntry(): ProfilerEntry {
@@ -129,6 +144,7 @@ export class ProfilerController implements Controller<ProfilerView> {
       meanCalc: new HistoryMeanCalculator( this.bufferSize ),
       medianCalc: new HistoryPercentileCalculator( this.bufferSize ),
       latest: 0.0,
+      measureEnd: null,
       childrenCacheMap: new ConsecutiveCacheMap(),
       childrenPromiseDelta: [],
     };


### PR DESCRIPTION
we can now use `profiler.measureStart( name )` and `profiler.measureEnd()`.

This provides more classical way to measure things like you do in `console.time` and `console.timeEnd`.

Also, `profiler.measure( name, fn )` can now receive asynchronous lambda, which awaits the async lambda to be resolved.

Because of the change, the interface of `ProfilerBladeMeasureHandler` has been changed.
It now receives `measureStart`, which is expected to return a function that returns a number instead of `measure`.
